### PR TITLE
fixed parsing of multiple dots in function name

### DIFF
--- a/src/Language/Lua/Parser.hs
+++ b/src/Language/Lua/Parser.hs
@@ -341,7 +341,7 @@ funAssignStat = do
   where funName :: Parser FunName
         funName = FunName <$> name
                           <*> many (tok LTokDot >> name)
-                          <*> many (tok LTokColon >> name)
+                          <*> optionMaybe (tok LTokColon >> name)
 
 localFunAssignStat = do
   tok LTokLocal

--- a/src/Language/Lua/PrettyPrinter.hs
+++ b/src/Language/Lua/PrettyPrinter.hs
@@ -92,7 +92,10 @@ instance LPretty Block where
                      Just e  -> nest 2 (text "return" </> (intercalate comma (map pprint e)))
 
 instance LPretty FunName where
-    pprint (FunName name s methods) = text name <> (intercalate dot (map pprint s))  <> (intercalate colon (map pprint methods))
+    pprint (FunName name s methods) = text name <> (intercalate dot (map pprint s))  <> methods'
+      where methods' = case methods of
+                   Nothing -> empty
+                   Just m' -> char '.' <> text m'
 
 instance LPretty FunDef where
     pprint (FunDef body) = pprint body

--- a/src/Language/Lua/Types.hs
+++ b/src/Language/Lua/Types.hs
@@ -67,7 +67,7 @@ data TableField
 data Block = Block [Stat] (Maybe [Exp])
     deriving (Show, Eq)
 
-data FunName = FunName Name [Name] [Name]
+data FunName = FunName Name [Name] (Maybe Name)
     deriving (Show, Eq)
 
 data FunDef = FunDef FunBody


### PR DESCRIPTION
as in Lua 5.2 manual (http://www.lua.org/manual/5.2/manual.html#3.4.10):

  The colon syntax is used for defining methods, that is, functions that
  have an implicit extra parameter self. Thus, the statement

```
function t.a.b.c:f (params) body end
```

  is syntactic sugar for

```
t.a.b.c.f = function (self, params) body end
```

I changed the datatype FunName:

  -data FunName = FunName Name (Maybe Name) [Name]
  +data FunName = FunName Name [Name] [Name]

This will break the API!
